### PR TITLE
Add the T in behat to fix 404

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,4 +14,4 @@
 # Development
 
 #### Automated Testing For WordPress Using Behat by Ari Gold
-- https://pantheon.io/blog/automated-testing-wordpress-using-beha
+- https://pantheon.io/blog/automated-testing-wordpress-using-behat


### PR DESCRIPTION
Landed here via Twitter, the link behat post was a 404 initially but this should work:

https://pantheon.io/blog/automated-testing-wordpress-using-behat
